### PR TITLE
Bump `ghostwriter/coding-standard` from `dev-main`

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2688,12 +2688,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "9cb01a5b8117431bf051fd63afae99372d9ee90d"
+                "reference": "630150015b4334fe9c622cb3522b049ef205d44f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/9cb01a5b8117431bf051fd63afae99372d9ee90d",
-                "reference": "9cb01a5b8117431bf051fd63afae99372d9ee90d",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/630150015b4334fe9c622cb3522b049ef205d44f",
+                "reference": "630150015b4334fe9c622cb3522b049ef205d44f",
                 "shasum": ""
             },
             "require": {
@@ -2850,7 +2850,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-08-24T04:50:34+00:00"
+            "time": "2025-08-24T12:36:48+00:00"
         },
         {
             "name": "ghostwriter/psr-phpunit-assertions",


### PR DESCRIPTION
Bumps `ghostwriter/coding-standard` from `dev-main`.

This pull request changes the following file(s): 

- Update `composer.lock`