### PR TITLE
Update ghostwriter/config to version 2.1.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "ghostwriter/case-converter": "^2.2.1",
         "ghostwriter/clock": "^3.0.1",
         "ghostwriter/collection": "^2.1.0",
-        "ghostwriter/config": "^2.1.2",
+        "ghostwriter/config": "^2.1.3",
         "ghostwriter/container": "^7.0.0",
         "ghostwriter/event-dispatcher": "^6.1.1",
         "ghostwriter/filesystem": "^0.2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b73adfe23abc50c89dfe896ffd0e1941",
+    "content-hash": "4737a053db03608031471757a519b028",
     "packages": [
         {
             "name": "ghostwriter/case-converter",
@@ -225,16 +225,16 @@
         },
         {
             "name": "ghostwriter/config",
-            "version": "2.1.2",
+            "version": "2.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/config.git",
-                "reference": "108d04cba1435d0d2fe1e366f19da869ff9e5284"
+                "reference": "9fbf1f2fccf86dbd4e06b5d9cef6d24a9ab0418d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/config/zipball/108d04cba1435d0d2fe1e366f19da869ff9e5284",
-                "reference": "108d04cba1435d0d2fe1e366f19da869ff9e5284",
+                "url": "https://api.github.com/repos/ghostwriter/config/zipball/9fbf1f2fccf86dbd4e06b5d9cef6d24a9ab0418d",
+                "reference": "9fbf1f2fccf86dbd4e06b5d9cef6d24a9ab0418d",
                 "shasum": ""
             },
             "require": {
@@ -297,7 +297,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-04-20T20:57:17+00:00"
+            "time": "2026-04-21T19:18:09+00:00"
         },
         {
             "name": "ghostwriter/container",


### PR DESCRIPTION
Updates the `ghostwriter/config` dependency from `2.1.2` to `2.1.3`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`