### PR TITLE
Update phpunit/phpunit to version 13.1.13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         "ext-xdebug": "*",
         "ghostwriter/coding-standard": "dev-main",
         "mockery/mockery": "^1.6.12",
-        "phpunit/phpunit": "^13.1.12",
+        "phpunit/phpunit": "^13.1.13",
         "symfony/var-dumper": "^8.0.8"
     },
     "prefer-stable": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1e641f081df59e24060b2566096d7bdf",
+    "content-hash": "a02707a091915d3016f7e1c11eded402",
     "packages": [
         {
             "name": "ghostwriter/case-converter",
@@ -1183,12 +1183,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "a9d36ba7ed296a96b1ab498415e01970deae4405"
+                "reference": "262e6b44d83cf8909f24b85a3e1b1bc93435e492"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/a9d36ba7ed296a96b1ab498415e01970deae4405",
-                "reference": "a9d36ba7ed296a96b1ab498415e01970deae4405",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/262e6b44d83cf8909f24b85a3e1b1bc93435e492",
+                "reference": "262e6b44d83cf8909f24b85a3e1b1bc93435e492",
                 "shasum": ""
             },
             "require": {
@@ -1240,7 +1240,7 @@
                 "ext-zlib": "*",
                 "mockery/mockery": "^1.6.12",
                 "php": "~8.4.0 || ~8.5.0",
-                "phpunit/phpunit": "^13.1.12",
+                "phpunit/phpunit": "^13.1.13",
                 "symfony/var-dumper": "^8.0.8"
             },
             "conflict": {
@@ -1303,7 +1303,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-27T12:16:09+00:00"
+            "time": "2026-05-27T14:24:53+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",
@@ -2060,16 +2060,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "13.1.12",
+            "version": "13.1.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "ca98c9f757c0e1e0778ab8ff80c4fb84152facf8"
+                "reference": "ddf7f25d9ee9652b464475d7f3bacde2613e355e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/ca98c9f757c0e1e0778ab8ff80c4fb84152facf8",
-                "reference": "ca98c9f757c0e1e0778ab8ff80c4fb84152facf8",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/ddf7f25d9ee9652b464475d7f3bacde2613e355e",
+                "reference": "ddf7f25d9ee9652b464475d7f3bacde2613e355e",
                 "shasum": ""
             },
             "require": {
@@ -2139,7 +2139,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/13.1.12"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/13.1.13"
             },
             "funding": [
                 {
@@ -2147,7 +2147,7 @@
                     "type": "other"
                 }
             ],
-            "time": "2026-05-25T15:37:19+00:00"
+            "time": "2026-05-27T14:03:08+00:00"
         },
         {
             "name": "sebastian/cli-parser",


### PR DESCRIPTION
Updates the `phpunit/phpunit` dependency from `13.1.12` to `13.1.13`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`